### PR TITLE
Import Encripted maFile

### DIFF
--- a/Steam Desktop Authenticator/Import_maFile_Form.Designer.cs
+++ b/Steam Desktop Authenticator/Import_maFile_Form.Designer.cs
@@ -14,6 +14,7 @@ namespace Steam_Desktop_Authenticator
             this.txtBox = new System.Windows.Forms.TextBox();
             this.btnImport = new System.Windows.Forms.Button();
             this.btnCancel = new System.Windows.Forms.Button();
+            this.label1 = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
             // labelText
@@ -23,21 +24,21 @@ namespace Steam_Desktop_Authenticator
             this.labelText.ForeColor = System.Drawing.SystemColors.ControlText;
             this.labelText.Location = new System.Drawing.Point(13, 14);
             this.labelText.Name = "labelText";
-            this.labelText.Size = new System.Drawing.Size(309, 25);
+            this.labelText.Size = new System.Drawing.Size(319, 25);
             this.labelText.TabIndex = 0;
-            this.labelText.Text = "Enter your encription pass key if your .maFile is encripted";
+            this.labelText.Text = "Enter your encryption pass key if your .maFile is encripted";
             // 
             // txtBox
             // 
             this.txtBox.Font = new System.Drawing.Font("Segoe UI", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.txtBox.Location = new System.Drawing.Point(15, 42);
             this.txtBox.Name = "txtBox";
-            this.txtBox.Size = new System.Drawing.Size(304, 33);
+            this.txtBox.Size = new System.Drawing.Size(307, 33);
             this.txtBox.TabIndex = 1;
             // 
             // btnImport
             // 
-            this.btnImport.Location = new System.Drawing.Point(16, 93);
+            this.btnImport.Location = new System.Drawing.Point(16, 129);
             this.btnImport.Name = "btnImport";
             this.btnImport.Size = new System.Drawing.Size(187, 28);
             this.btnImport.TabIndex = 2;
@@ -48,7 +49,7 @@ namespace Steam_Desktop_Authenticator
             // btnCancel
             // 
             this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.btnCancel.Location = new System.Drawing.Point(221, 93);
+            this.btnCancel.Location = new System.Drawing.Point(224, 129);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(98, 28);
             this.btnCancel.TabIndex = 3;
@@ -56,13 +57,25 @@ namespace Steam_Desktop_Authenticator
             this.btnCancel.UseVisualStyleBackColor = true;
             this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
             // 
+            // label1
+            // 
+            this.label1.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.label1.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.label1.Location = new System.Drawing.Point(13, 83);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(309, 40);
+            this.label1.TabIndex = 4;
+            this.label1.Text = "If you import a .maFile encrypted, the file manifest.json needs to be next to it";
+            // 
             // Import_maFile_Form
             // 
             this.AcceptButton = this.btnImport;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.btnCancel;
-            this.ClientSize = new System.Drawing.Size(334, 136);
+            this.ClientSize = new System.Drawing.Size(336, 171);
+            this.Controls.Add(this.label1);
             this.Controls.Add(this.btnCancel);
             this.Controls.Add(this.btnImport);
             this.Controls.Add(this.txtBox);
@@ -84,5 +97,6 @@ namespace Steam_Desktop_Authenticator
         private System.Windows.Forms.TextBox txtBox;
         private System.Windows.Forms.Button btnImport;
         private System.Windows.Forms.Button btnCancel;
+        private System.Windows.Forms.Label label1;
     }
 }

--- a/Steam Desktop Authenticator/Import_maFile_Form.Designer.cs
+++ b/Steam Desktop Authenticator/Import_maFile_Form.Designer.cs
@@ -1,0 +1,88 @@
+namespace Steam_Desktop_Authenticator
+{
+    partial class Import_maFile_Form
+    {
+        #region Windows Form Designer generated code
+
+        /// <summary>
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
+        /// </summary>
+        private void InitializeComponent()
+        {
+            this.labelText = new System.Windows.Forms.Label();
+            this.txtBox = new System.Windows.Forms.TextBox();
+            this.btnImport = new System.Windows.Forms.Button();
+            this.btnCancel = new System.Windows.Forms.Button();
+            this.SuspendLayout();
+            // 
+            // labelText
+            // 
+            this.labelText.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.labelText.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.labelText.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.labelText.Location = new System.Drawing.Point(13, 14);
+            this.labelText.Name = "labelText";
+            this.labelText.Size = new System.Drawing.Size(309, 25);
+            this.labelText.TabIndex = 0;
+            this.labelText.Text = "Enter your encription pass key if your .maFile is encripted";
+            // 
+            // txtBox
+            // 
+            this.txtBox.Font = new System.Drawing.Font("Segoe UI", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.txtBox.Location = new System.Drawing.Point(15, 42);
+            this.txtBox.Name = "txtBox";
+            this.txtBox.Size = new System.Drawing.Size(304, 33);
+            this.txtBox.TabIndex = 1;
+            // 
+            // btnImport
+            // 
+            this.btnImport.Location = new System.Drawing.Point(16, 93);
+            this.btnImport.Name = "btnImport";
+            this.btnImport.Size = new System.Drawing.Size(187, 28);
+            this.btnImport.TabIndex = 2;
+            this.btnImport.Text = "Select .maFile file to Import";
+            this.btnImport.UseVisualStyleBackColor = true;
+            this.btnImport.Click += new System.EventHandler(this.btnImport_Click);
+            // 
+            // btnCancel
+            // 
+            this.btnCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            this.btnCancel.Location = new System.Drawing.Point(221, 93);
+            this.btnCancel.Name = "btnCancel";
+            this.btnCancel.Size = new System.Drawing.Size(98, 28);
+            this.btnCancel.TabIndex = 3;
+            this.btnCancel.Text = "Cancel";
+            this.btnCancel.UseVisualStyleBackColor = true;
+            this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
+            // 
+            // Import_maFile_Form
+            // 
+            this.AcceptButton = this.btnImport;
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.CancelButton = this.btnCancel;
+            this.ClientSize = new System.Drawing.Size(334, 136);
+            this.Controls.Add(this.btnCancel);
+            this.Controls.Add(this.btnImport);
+            this.Controls.Add(this.txtBox);
+            this.Controls.Add(this.labelText);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+            this.MaximizeBox = false;
+            this.Name = "Import_maFile_Form";
+            this.ShowInTaskbar = false;
+            this.Text = "Import .maFile";
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.Import_maFile_Form_FormClosing);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label labelText;
+        private System.Windows.Forms.TextBox txtBox;
+        private System.Windows.Forms.Button btnImport;
+        private System.Windows.Forms.Button btnCancel;
+    }
+}

--- a/Steam Desktop Authenticator/Import_maFile_Form.Designer.cs
+++ b/Steam Desktop Authenticator/Import_maFile_Form.Designer.cs
@@ -36,12 +36,23 @@ namespace Steam_Desktop_Authenticator
             this.txtBox.Size = new System.Drawing.Size(307, 33);
             this.txtBox.TabIndex = 1;
             // 
+            // info
+            // 
+            this.label1.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
+            this.label1.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.label1.ForeColor = System.Drawing.SystemColors.ControlText;
+            this.label1.Location = new System.Drawing.Point(13, 83);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(309, 40);
+            this.label1.TabIndex = 2;
+            this.label1.Text = "If you import a .maFile encrypted, the file manifest.json needs to be next to it";
+            // 
             // btnImport
             // 
             this.btnImport.Location = new System.Drawing.Point(16, 129);
             this.btnImport.Name = "btnImport";
             this.btnImport.Size = new System.Drawing.Size(187, 28);
-            this.btnImport.TabIndex = 2;
+            this.btnImport.TabIndex = 3;
             this.btnImport.Text = "Select .maFile file to Import";
             this.btnImport.UseVisualStyleBackColor = true;
             this.btnImport.Click += new System.EventHandler(this.btnImport_Click);
@@ -52,21 +63,11 @@ namespace Steam_Desktop_Authenticator
             this.btnCancel.Location = new System.Drawing.Point(224, 129);
             this.btnCancel.Name = "btnCancel";
             this.btnCancel.Size = new System.Drawing.Size(98, 28);
-            this.btnCancel.TabIndex = 3;
+            this.btnCancel.TabIndex = 4;
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
             this.btnCancel.Click += new System.EventHandler(this.btnCancel_Click);
-            // 
-            // label1
-            // 
-            this.label1.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.label1.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.label1.ForeColor = System.Drawing.SystemColors.ControlText;
-            this.label1.Location = new System.Drawing.Point(13, 83);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(309, 40);
-            this.label1.TabIndex = 4;
-            this.label1.Text = "If you import a .maFile encrypted, the file manifest.json needs to be next to it";
+
             // 
             // Import_maFile_Form
             // 

--- a/Steam Desktop Authenticator/Import_maFile_Form.cs
+++ b/Steam Desktop Authenticator/Import_maFile_Form.cs
@@ -1,0 +1,289 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Data;
+using System.Drawing;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using SteamAuth;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using System.IO;
+
+namespace Steam_Desktop_Authenticator
+{
+    public partial class Import_maFile_Form : Form
+    {
+        private SteamGuardAccount mCurrentAccount = null;
+        private Manifest mManifest;
+
+        public Import_maFile_Form()
+        {
+            InitializeComponent();
+
+            this.mManifest = Manifest.GetManifest();
+
+        }
+
+        private void btnImport_Click(object sender, EventArgs e)
+        {
+            // check if data already added is encripted
+            #region check if data already added is encripted
+                string ContiuneImport = "0";
+
+                string ManifestFile = "maFiles/manifest.json";
+                if (File.Exists(ManifestFile))
+                {
+                    string AppManifestContents = File.ReadAllText(ManifestFile);
+                    AppManifest AppManifestData = JsonConvert.DeserializeObject<AppManifest>(AppManifestContents);
+                        bool AppManifestData_encrypted = AppManifestData.Encrypted;
+                        if (AppManifestData_encrypted == true)
+                        {
+                            MessageBox.Show("You can't import an .maFile because the existing account in the app is encrypted.\nDecrypt it and try again.");
+                            this.Close();
+                        }
+                        else if (AppManifestData_encrypted == false)
+                        {
+                            ContiuneImport = "1";
+                        }
+                        else 
+                        {
+                            MessageBox.Show("invalid value for variable 'encrypted' inside manifest.json");
+                            this.Close();
+                        }
+                }
+                else 
+                {
+                    MessageBox.Show("An Error occurred, Restart the program!");
+                }
+            #endregion
+
+            // Continue
+            #region Continue
+                if (ContiuneImport == "1") {
+                this.Close();
+
+                // read EncriptionKey from imput box
+                string ImportUsingEncriptionKey = txtBox.Text;
+
+                // Open file browser > to select the file
+                OpenFileDialog openFileDialog1 = new OpenFileDialog();
+
+                // Set filter options and filter index.
+                openFileDialog1.Filter = "maFiles (.maFile)|*.maFile|All Files (*.*)|*.*";
+                openFileDialog1.FilterIndex = 1;
+                openFileDialog1.Multiselect = false;
+
+                // Call the ShowDialog method to show the dialog box.
+                DialogResult userClickedOK = openFileDialog1.ShowDialog();
+
+                // Process input if the user clicked OK.
+                if (userClickedOK == DialogResult.OK)
+                {
+                    // Open the selected file to read.
+                    System.IO.Stream fileStream = openFileDialog1.OpenFile();
+                    string fileContents = null;
+
+                    using (System.IO.StreamReader reader = new System.IO.StreamReader(fileStream))
+                    {
+                        fileContents = reader.ReadToEnd();
+                    }
+                    fileStream.Close();
+
+                    try
+                    {
+                        if (ImportUsingEncriptionKey == "")
+                        {
+                            // Import maFile
+                            //-------------------------------------------
+                            #region Import maFile
+                            SteamGuardAccount maFile = JsonConvert.DeserializeObject<SteamGuardAccount>(fileContents);
+                            if (maFile.Session.SteamID != 0)
+                            {
+                                mManifest.SaveAccount(maFile, false);
+                                MessageBox.Show("Account Imported!");
+                            }
+                            else
+                            {
+                                throw new Exception("Invalid SteamID");
+                            }
+                            #endregion
+                        }
+                        else
+                        {
+                            // Import Encripted maFile
+                            //-------------------------------------------
+                            #region Import Encripted maFile
+                                //Read manifest.json encryption_iv encryption_salt
+                                string ImportFileName_Found = "0";
+                                string Salt_Found = null;
+                                string IV_Found = null;
+                                string ReadManifestEx = "0";
+
+                                //No directory means no manifest file anyways.
+                                ImportManifest newImportManifest = new ImportManifest();
+                                newImportManifest.Encrypted = false;
+                                newImportManifest.Entries = new List<ImportManifestEntry>();
+
+                                // extract folder path
+                                string fullPath = openFileDialog1.FileName;
+                                string fileName = openFileDialog1.SafeFileName;
+                                string path = fullPath.Replace(fileName, "");
+
+                                // extract fileName
+                                string ImportFileName = fullPath.Replace(path, "");
+
+                                string ImportManifestFile = path + "manifest.json";
+
+
+                                if (File.Exists(ImportManifestFile))
+                                {
+                                    string ImportManifestContents = File.ReadAllText(ImportManifestFile);
+
+
+                                    try
+                                    {
+                                        ImportManifest account = JsonConvert.DeserializeObject<ImportManifest>(ImportManifestContents);
+                                        //bool Import_encrypted = account.Encrypted;
+
+                                        List<ImportManifest> newEntries = new List<ImportManifest>();
+
+                                        foreach (var entry in account.Entries)
+                                        {
+                                            string FileName = entry.Filename;
+                                            string encryption_iv = entry.IV;
+                                            string encryption_salt = entry.Salt;
+
+                                            if (ImportFileName == FileName)
+                                            {
+                                                ImportFileName_Found = "1";
+                                                IV_Found = entry.IV;
+                                                Salt_Found = entry.Salt;
+                                            }
+                                        }
+                                    }
+                                    catch (Exception)
+                                    {
+                                        ReadManifestEx = "1";
+                                        MessageBox.Show("Invalid content inside manifest.json!\nImport Failed.");
+                                    }
+
+
+                                    // DECRIPT & Import
+                                    //--------------------
+                                    #region DECRIPT & Import
+                                        if (ReadManifestEx == "0")
+                                        {
+                                            if (ImportFileName_Found == "1" && Salt_Found != null && IV_Found != null)
+                                            {
+                                                string decryptedText = FileEncryptor.DecryptData(ImportUsingEncriptionKey, Salt_Found, IV_Found, fileContents);
+
+                                                if (decryptedText == null)
+                                                {
+                                                    MessageBox.Show("Decryption Failed.\nImport Failed.");
+                                                }
+                                                else
+                                                {
+                                                    string fileText = decryptedText;
+
+                                                    SteamGuardAccount maFile = JsonConvert.DeserializeObject<SteamGuardAccount>(fileText);
+                                                    if (maFile.Session.SteamID != 0)
+                                                    {
+                                                        mManifest.SaveAccount(maFile, false);
+                                                        MessageBox.Show("Account Imported!\nYour Account in now Decrypted!");
+                                                        //MainForm.loadAccountsList();
+                                                    }
+                                                    else
+                                                    {
+                                                        MessageBox.Show("Invalid SteamID.\nImport Failed.");
+                                                    }
+                                                }
+                                            }
+                                            else
+                                            {
+                                                if (ImportFileName_Found == "0")
+                                                {
+                                                    MessageBox.Show("Account not found inside manifest.json.\nImport Failed.");
+                                                }
+                                                else if (Salt_Found == null && IV_Found == null)
+                                                {
+                                                    MessageBox.Show("manifest.json does not contain encrypted data.\nYour account may be unencrypted!\nImport Failed.");
+                                                }
+                                                else
+                                                {
+                                                    if (IV_Found == null)
+                                                    {
+                                                        MessageBox.Show("manifest.json does not contain: encryption_iv\nImport Failed.");
+                                                    }
+                                                    else if (IV_Found == null)
+                                                    {
+                                                        MessageBox.Show("manifest.json does not contain: encryption_salt\nImport Failed.");
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    #endregion //DECRIPT & Import END
+
+
+                                }
+                                else
+                                {
+                                    MessageBox.Show("manifest.json is missing!\nImport Failed.");
+                                }
+                            #endregion //Import Encripted maFile END
+                        }
+
+                    }
+                    catch (Exception)
+                    {
+                        MessageBox.Show("This file is not a valid SteamAuth maFile.\nImport Failed.");
+                    }
+                }
+            }
+            #endregion // Continue End
+        }
+
+        private void btnCancel_Click(object sender, EventArgs e)
+        {
+            this.Close();
+        }
+
+        private void Import_maFile_Form_FormClosing(object sender, FormClosingEventArgs e)
+        {
+        }
+    }
+
+
+    public class AppManifest
+    {
+        [JsonProperty("encrypted")]
+        public bool Encrypted { get; set; }
+    }
+
+
+    public class ImportManifest
+    {
+        [JsonProperty("encrypted")]
+        public bool Encrypted { get; set; }
+
+        [JsonProperty("entries")]
+        public List<ImportManifestEntry> Entries { get; set; }
+    }
+
+    public class ImportManifestEntry
+    {
+        [JsonProperty("encryption_iv")]
+        public string IV { get; set; }
+
+        [JsonProperty("encryption_salt")]
+        public string Salt { get; set; }
+
+        [JsonProperty("filename")]
+        public string Filename { get; set; }
+
+        [JsonProperty("steamid")]
+        public ulong SteamID { get; set; }
+    }
+}

--- a/Steam Desktop Authenticator/Import_maFile_Form.resx
+++ b/Steam Desktop Authenticator/Import_maFile_Form.resx
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+</root>

--- a/Steam Desktop Authenticator/MainForm.cs
+++ b/Steam Desktop Authenticator/MainForm.cs
@@ -266,48 +266,9 @@ namespace Steam_Desktop_Authenticator
 
         private void menuImportMaFile_Click(object sender, EventArgs e)
         {
-            OpenFileDialog openFileDialog1 = new OpenFileDialog();
-
-            // Set filter options and filter index.
-            openFileDialog1.Filter = "maFiles (.maFile)|*.maFile|All Files (*.*)|*.*";
-            openFileDialog1.FilterIndex = 1;
-            openFileDialog1.Multiselect = false;
-
-            // Call the ShowDialog method to show the dialog box.
-            DialogResult userClickedOK = openFileDialog1.ShowDialog();
-
-            // Process input if the user clicked OK.
-            if (userClickedOK == DialogResult.OK)
-            {
-                // Open the selected file to read.
-                System.IO.Stream fileStream = openFileDialog1.OpenFile();
-                string fileContents = null;
-
-                using (System.IO.StreamReader reader = new System.IO.StreamReader(fileStream))
-                {
-                    fileContents = reader.ReadToEnd();
-                }
-                fileStream.Close();
-
-                try
-                {
-                    SteamGuardAccount maFile = JsonConvert.DeserializeObject<SteamGuardAccount>(fileContents);
-                    if (maFile.Session.SteamID != 0)
-                    {
-                        mManifest.SaveAccount(maFile, false);
-                        MessageBox.Show("Account Imported!");
-                        loadAccountsList();
-                    }
-                    else
-                    {
-                        throw new Exception("Invalid SteamID");
-                    }
-                }
-                catch (Exception)
-                {
-                    MessageBox.Show("Failed to parse JSON file. Import Failed.");
-                }
-            }
+            Import_maFile_Form currentImport_maFile_Form = new Import_maFile_Form();
+            currentImport_maFile_Form.ShowDialog();
+            loadAccountsList();
         }
 
         private void menuQuit_Click(object sender, EventArgs e)

--- a/Steam Desktop Authenticator/Steam Desktop Authenticator.csproj
+++ b/Steam Desktop Authenticator/Steam Desktop Authenticator.csproj
@@ -138,6 +138,12 @@
     <Compile Include="CaptchaForm.Designer.cs">
       <DependentUpon>CaptchaForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="Import_maFile_Form.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Import_maFile_Form.Designer.cs">
+      <DependentUpon>Import_maFile_Form.cs</DependentUpon>
+    </Compile>
     <Compile Include="InputForm.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -177,6 +183,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="ConfirmationFormWeb.resx">
       <DependentUpon>ConfirmationFormWeb.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Import_maFile_Form.resx">
+      <DependentUpon>Import_maFile_Form.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="InputForm.resx">
       <DependentUpon>InputForm.cs</DependentUpon>


### PR DESCRIPTION
Now it works to import encripted maFiles, but it needs manifest.json to be next to that file

Created a Window Form for import maFile
- Inside it is a imput box for password (in case the imported maFile is encrypted)
- Importing:
  - when User clicks button Import If the current manifest.json is `"encrypted":true` he will get a msg
`You can't import an .maFile because the existing account in the app is encrypted. Decrypt it and try again.`
  - If user adds an encrypted maFile, the file will be decrypted and added
  - Alot of MessageBox added
