### PR TITLE
Reorder manifest entries and search accounts

### DIFF
--- a/Steam Desktop Authenticator/MainForm.Designer.cs
+++ b/Steam Desktop Authenticator/MainForm.Designer.cs
@@ -63,6 +63,7 @@
             this.trayQuit = new System.Windows.Forms.ToolStripMenuItem();
             this.timerTradesPopup = new System.Windows.Forms.Timer(this.components);
             this.lblStatus = new System.Windows.Forms.Label();
+            this.txtAccSearch = new System.Windows.Forms.TextBox();
             this.groupBox1.SuspendLayout();
             this.groupBox2.SuspendLayout();
             this.menuStrip.SuspendLayout();
@@ -129,11 +130,12 @@
             this.listAccounts.Size = new System.Drawing.Size(327, 160);
             this.listAccounts.TabIndex = 3;
             this.listAccounts.SelectedValueChanged += new System.EventHandler(this.listAccounts_SelectedValueChanged);
+            this.listAccounts.KeyDown += new System.Windows.Forms.KeyEventHandler(this.listAccounts_KeyDown);
             // 
             // timerSteamGuard
             // 
             this.timerSteamGuard.Enabled = true;
-            this.timerSteamGuard.Interval = 1000;
+            this.timerSteamGuard.Interval = 5000;
             this.timerSteamGuard.Tick += new System.EventHandler(this.timerSteamGuard_Tick);
             // 
             // btnTradeConfirmations
@@ -311,7 +313,7 @@
             this.toolStripSeparator3,
             this.trayQuit});
             this.menuStripTray.Name = "contextMenuStripTray";
-            this.menuStripTray.Size = new System.Drawing.Size(216, 153);
+            this.menuStripTray.Size = new System.Drawing.Size(216, 131);
             // 
             // trayRestore
             // 
@@ -378,12 +380,22 @@
             this.lblStatus.TabIndex = 11;
             this.lblStatus.TextAlign = System.Drawing.ContentAlignment.TopRight;
             // 
+            // txtAccSearch
+            // 
+            this.txtAccSearch.Location = new System.Drawing.Point(14, 355);
+            this.txtAccSearch.Name = "txtAccSearch";
+            this.txtAccSearch.Size = new System.Drawing.Size(99, 20);
+            this.txtAccSearch.TabIndex = 12;
+            this.txtAccSearch.Visible = false;
+            this.txtAccSearch.TextChanged += new System.EventHandler(this.txtAccSearch_TextChanged);
+            // 
             // MainForm
             // 
             this.AcceptButton = this.btnSteamLogin;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(351, 403);
+            this.Controls.Add(this.txtAccSearch);
             this.Controls.Add(this.lblStatus);
             this.Controls.Add(this.labelUpdate);
             this.Controls.Add(this.labelVersion);
@@ -447,6 +459,7 @@
         private System.Windows.Forms.ToolStripMenuItem menuImportMaFile;
         private System.Windows.Forms.ToolStripMenuItem menuImportAndroid;
         private System.Windows.Forms.Label lblStatus;
+        private System.Windows.Forms.TextBox txtAccSearch;
     }
 }
 

--- a/Steam Desktop Authenticator/MainForm.Designer.cs
+++ b/Steam Desktop Authenticator/MainForm.Designer.cs
@@ -137,7 +137,7 @@
             // timerSteamGuard
             // 
             this.timerSteamGuard.Enabled = true;
-            this.timerSteamGuard.Interval = 5000;
+            this.timerSteamGuard.Interval = 1000;
             this.timerSteamGuard.Tick += new System.EventHandler(this.timerSteamGuard_Tick);
             // 
             // btnTradeConfirmations

--- a/Steam Desktop Authenticator/MainForm.Designer.cs
+++ b/Steam Desktop Authenticator/MainForm.Designer.cs
@@ -133,6 +133,7 @@
             this.listAccounts.TabIndex = 3;
             this.listAccounts.SelectedValueChanged += new System.EventHandler(this.listAccounts_SelectedValueChanged);
             this.listAccounts.KeyDown += new System.Windows.Forms.KeyEventHandler(this.listAccounts_KeyDown);
+            this.listAccounts.KeyUp += new System.Windows.Forms.KeyEventHandler(this.listAccounts_KeyUp);
             // 
             // timerSteamGuard
             // 

--- a/Steam Desktop Authenticator/MainForm.cs
+++ b/Steam Desktop Authenticator/MainForm.cs
@@ -463,7 +463,9 @@ namespace Steam_Desktop_Authenticator
                 }
                 return;
             }
-            if (!IsKeyAChar(e.KeyCode) || !IsKeyADigit(e.KeyCode)) return;
+            if (!IsKeyAChar(e.KeyCode))
+                if (!IsKeyADigit(e.KeyCode))
+                    return;
             txtAccSearch.Show();
             txtAccSearch.Focus();
             txtAccSearch.Text = e.KeyCode.ToString();

--- a/Steam Desktop Authenticator/MainForm.cs
+++ b/Steam Desktop Authenticator/MainForm.cs
@@ -3,6 +3,8 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using SteamAuth;
 using Squirrel;
+using System.Collections.Generic;
+using System.Text.RegularExpressions;
 
 namespace Steam_Desktop_Authenticator
 {
@@ -414,6 +416,51 @@ namespace Steam_Desktop_Authenticator
             {
                 await mgr.UpdateApp();
             }
+        }
+
+        private void listAccounts_KeyDown(object sender, KeyEventArgs e)
+        {
+            txtAccSearch.Show();
+            txtAccSearch.Focus();
+            txtAccSearch.Text = e.KeyCode.ToString();
+        }
+
+        private void txtAccSearch_TextChanged(object sender, EventArgs e)
+        {
+            List<string> names = new List<string>(getAllNames());
+            names = names.FindAll(new Predicate<string>(IsFilter));
+
+            listAccounts.Items.Clear();
+            listAccounts.Items.AddRange(names.ToArray());
+        }
+
+        private bool IsFilter(string f)
+        {
+            if (txtAccSearch.Text.StartsWith("~"))
+                return Regex.IsMatch(f, txtAccSearch.Text);
+            else
+                return f.Contains(txtAccSearch.Text);
+        }
+
+        private string[] getAllNames()
+        {
+            string[] itemArray = new string[allAccounts.Length];
+            for (int i = 0; i < itemArray.Length; i++)
+            {
+                itemArray[i] = allAccounts[i].AccountName;
+            }
+            return itemArray;
+        }
+
+        private string[] getListboxItems(ListBox lb)
+        {
+            string[] itemArray = new string[lb.Items.Count];
+            int itemCount = lb.Items.Count;
+            for (int i = 0; i < itemCount; i++)
+            {
+                itemArray[i] = lb.Items[i].ToString();
+            }
+            return itemArray;
         }
     }
 }

--- a/Steam Desktop Authenticator/MainForm.cs
+++ b/Steam Desktop Authenticator/MainForm.cs
@@ -457,8 +457,8 @@ namespace Steam_Desktop_Authenticator
             {
                 if (e.KeyCode == Keys.Up || e.KeyCode == Keys.Down)
                 {
-                    manifest.MoveEntry(listAccounts.SelectedIndex,
-                        listAccounts.SelectedIndex - (e.KeyCode == Keys.Up ? 1 : -1));
+                    int to = listAccounts.SelectedIndex - (e.KeyCode == Keys.Up ? 1 : -1);
+                    manifest.MoveEntry(listAccounts.SelectedIndex, to);
                     loadAccountsList();
                 }
                 return;

--- a/Steam Desktop Authenticator/MainForm.cs
+++ b/Steam Desktop Authenticator/MainForm.cs
@@ -453,9 +453,30 @@ namespace Steam_Desktop_Authenticator
 
         private void listAccounts_KeyDown(object sender, KeyEventArgs e)
         {
+            if (e.Control)
+            {
+                if (e.KeyCode == Keys.Up || e.KeyCode == Keys.Down)
+                {
+                    manifest.MoveEntry(listAccounts.SelectedIndex,
+                        listAccounts.SelectedIndex - (e.KeyCode == Keys.Up ? 1 : -1));
+                    loadAccountsList();
+                }
+                return;
+            }
+            if (!IsKeyAChar(e.KeyCode) || !IsKeyADigit(e.KeyCode)) return;
             txtAccSearch.Show();
             txtAccSearch.Focus();
             txtAccSearch.Text = e.KeyCode.ToString();
+        }
+
+        private static bool IsKeyAChar(Keys key)
+        {
+            return key >= Keys.A && key <= Keys.Z;
+        }
+
+        private static bool IsKeyADigit(Keys key)
+        {
+            return (key >= Keys.D0 && key <= Keys.D9) || (key >= Keys.NumPad0 && key <= Keys.NumPad9);
         }
 
         private void txtAccSearch_TextChanged(object sender, EventArgs e)
@@ -494,6 +515,11 @@ namespace Steam_Desktop_Authenticator
                 itemArray[i] = lb.Items[i].ToString();
             }
             return itemArray;
+        }
+
+        private void listAccounts_KeyUp(object sender, KeyEventArgs e)
+        {
+            
         }
     }
 }

--- a/Steam Desktop Authenticator/Manifest.cs
+++ b/Steam Desktop Authenticator/Manifest.cs
@@ -427,6 +427,14 @@ namespace Steam_Desktop_Authenticator
             }
         }
 
+        public void MoveEntry(int from, int to)
+        {
+            ManifestEntry sel = Entries[from];
+            Entries.RemoveAt(from);
+            Entries.Insert(to, sel);
+            Save();
+        }
+
         public class ManifestEntry
         {
             [JsonProperty("encryption_iv")]

--- a/Steam Desktop Authenticator/TradePopupForm.cs
+++ b/Steam Desktop Authenticator/TradePopupForm.cs
@@ -87,6 +87,9 @@ namespace Steam_Desktop_Authenticator
             btnAccept.BackColor = Color.FromArgb(192, 255, 192);
             btnDeny.BackColor = Color.FromArgb(255, 255, 192);
 
+            btnAccept.Text = "Accept";
+            btnDeny.Text = "Deny";
+
             if (confirms.Count == 0)
             {
                 this.Hide();


### PR DESCRIPTION
Now, you will be able to reorder entries on the main form by pression Control + (Up/Down) on the accounts list, and search for accounts also on the accounts list simply by typing.