### PR TITLE
12.03.2016 A bit of securely added to auto confirm, for encrypted accounts

### DIFF
--- a/Steam Desktop Authenticator/MainForm.cs
+++ b/Steam Desktop Authenticator/MainForm.cs
@@ -66,8 +66,10 @@ namespace Steam_Desktop_Authenticator
             
             //Startup start Auto-confirm Securely
             #region Startup Auto-confirms
-            int StartupMode = 1; // 1= user, secure startup // 2 = auto start, unsecure start for Auto Confirm (for bots - set value 2 and recompile) 
-
+            int StartupMode = 1; 
+            
+            if (manifest.Encrypted) { StartupMode = 1; /*secure*/ } else { StartupMode = 2; /*unsecure*/  }
+            
             if (StartupMode == 1)
             {
                 if (manifest.PeriodicChecking == true)

--- a/Steam Desktop Authenticator/MainForm.cs
+++ b/Steam Desktop Authenticator/MainForm.cs
@@ -63,6 +63,27 @@ namespace Steam_Desktop_Authenticator
             btnManageEncryption.Enabled = manifest.Entries.Count > 0;
 
             loadSettings();
+            
+            //Startup start Auto-confirm Securely
+            if (manifest.PopupConfirmationPeriodicChecking == true)
+            {
+                if (manifest.AutoConfirmTrades == true || manifest.AutoConfirmMarketTransactions == true) {
+
+                    bool EnableAutoConfirm_TradesAndMarket_Securely_atStartup = Manifest.PromptForSecureActvationAutoConfirm("startup_confirmation");
+
+                    if (EnableAutoConfirm_TradesAndMarket_Securely_atStartup == true) { 
+                        if (manifest.AutoConfirmTrades == true)
+                        {
+                            Manifest.AutoConfirm_IsStartedSecurely("set", true, "trade");
+                        }
+                        if (manifest.AutoConfirmMarketTransactions == true)
+                        {
+                            Manifest.AutoConfirm_IsStartedSecurely("set", true, "market");
+                        }
+                    }
+                }
+            }
+            
             loadAccountsList();
 
             checkForUpdates();
@@ -418,7 +439,9 @@ namespace Steam_Desktop_Authenticator
             try
             {
                 lblStatus.Text = "Checking confirmations...";
-
+                bool GetStatus_AutoConfirmSecurely_Trades = Manifest.AutoConfirm_IsStartedSecurely("read", false, "trades");
+				bool GetStatus_AutoConfirmSecurely_Market = Manifest.AutoConfirm_IsStartedSecurely("read", false, "market");
+                
                 foreach (var acc in accs)
                 {
                     try
@@ -426,9 +449,9 @@ namespace Steam_Desktop_Authenticator
                         Confirmation[] tmp = await currentAccount.FetchConfirmationsAsync();
                         foreach(var conf in tmp)
                         {
-                            if (conf.ConfType == Confirmation.ConfirmationType.MarketSellTransaction && manifest.AutoConfirmMarketTransactions)
+                            if (conf.ConfType == Confirmation.ConfirmationType.MarketSellTransaction && GetStatus_AutoConfirmSecurely_Market)
                                 acc.AcceptConfirmation(conf);
-                            else if (conf.ConfType == Confirmation.ConfirmationType.Trade && manifest.AutoConfirmTrades)
+                            else if (conf.ConfType == Confirmation.ConfirmationType.Trade && GetStatus_AutoConfirmSecurely_Trades)
                                 acc.AcceptConfirmation(conf);
                             else
                                 confs.Add(conf);

--- a/Steam Desktop Authenticator/MainForm.cs
+++ b/Steam Desktop Authenticator/MainForm.cs
@@ -65,29 +65,47 @@ namespace Steam_Desktop_Authenticator
             loadSettings();
             
             //Startup start Auto-confirm Securely
-            if (manifest.PeriodicChecking == true)
+            #region Startup Auto-confirms
+            int StartupMode = 1; // 1= user, secure startup // 2 = auto start, unsecure start for Auto Confirm (for bots - set value 2 and recompile) 
+
+            if (StartupMode == 1)
             {
-                if (manifest.AutoConfirmTrades == true || manifest.AutoConfirmMarketTransactions == true)
+                if (manifest.PeriodicChecking == true)
                 {
-
-                    bool EnableAutoConfirm_TradesAndMarket_Securely_atStartup = Manifest.PromptForSecureActvationAutoConfirm("startup_confirmation");
-
-                    if (EnableAutoConfirm_TradesAndMarket_Securely_atStartup == true)
+                    if (manifest.AutoConfirmTrades == true || manifest.AutoConfirmMarketTransactions == true)
                     {
-                        if (manifest.AutoConfirmTrades == true)
+
+                        bool EnableAutoConfirm_TradesAndMarket_Securely_atStartup = Manifest.PromptForSecureActvationAutoConfirm("startup_confirmation");
+
+                        if (EnableAutoConfirm_TradesAndMarket_Securely_atStartup == true)
                         {
-                            Manifest.AutoConfirm_IsStartedSecurely("set", true, "trade");
-                        }
-                        if (manifest.AutoConfirmMarketTransactions == true)
-                        {
-                            Manifest.AutoConfirm_IsStartedSecurely("set", true, "market");
+                            if (manifest.AutoConfirmTrades == true)
+                            {
+                                Manifest.AutoConfirm_IsStartedSecurely("set", true, "trade");
+                            }
+                            if (manifest.AutoConfirmMarketTransactions == true)
+                            {
+                                Manifest.AutoConfirm_IsStartedSecurely("set", true, "market");
+                            }
                         }
                     }
                 }
             }
+
+            if (StartupMode == 2)
+            {
+                if (manifest.AutoConfirmTrades == true)
+                {
+                    Manifest.AutoConfirm_IsStartedSecurely("set", true, "trade");
+                }
+                if (manifest.AutoConfirmMarketTransactions == true)
+                {
+                    Manifest.AutoConfirm_IsStartedSecurely("set", true, "market");
+                }
+            }
+            #endregion //Startup Auto-confirms
             
             loadAccountsList();
-
             checkForUpdates();
         }
 

--- a/Steam Desktop Authenticator/MainForm.cs
+++ b/Steam Desktop Authenticator/MainForm.cs
@@ -65,13 +65,15 @@ namespace Steam_Desktop_Authenticator
             loadSettings();
             
             //Startup start Auto-confirm Securely
-            if (manifest.PopupConfirmationPeriodicChecking == true)
+            if (manifest.PeriodicChecking == true)
             {
-                if (manifest.AutoConfirmTrades == true || manifest.AutoConfirmMarketTransactions == true) {
+                if (manifest.AutoConfirmTrades == true || manifest.AutoConfirmMarketTransactions == true)
+                {
 
                     bool EnableAutoConfirm_TradesAndMarket_Securely_atStartup = Manifest.PromptForSecureActvationAutoConfirm("startup_confirmation");
 
-                    if (EnableAutoConfirm_TradesAndMarket_Securely_atStartup == true) { 
+                    if (EnableAutoConfirm_TradesAndMarket_Securely_atStartup == true)
+                    {
                         if (manifest.AutoConfirmTrades == true)
                         {
                             Manifest.AutoConfirm_IsStartedSecurely("set", true, "trade");

--- a/Steam Desktop Authenticator/Manifest.cs
+++ b/Steam Desktop Authenticator/Manifest.cs
@@ -87,9 +87,16 @@ namespace Steam_Desktop_Authenticator
                 {
                     TotalRentryTimes_AutoConfirm_Passkey++;
 
-					string AutoConfirm_Passkey = SecureStartAutoConfirm();
+                    string AutoConfirm_Passkey = SecureStartAutoConfirm();
+
+                    string AutoConfirmInfo = "";
+                    var manifest = Manifest.GetManifest();
+                    if (manifest.AutoConfirmTrades == true) { AutoConfirmInfo = " Trades"; }
+                    if (manifest.AutoConfirmMarketTransactions == true) {
+                        if (AutoConfirmInfo == "") { AutoConfirmInfo = " Market"; } else { AutoConfirmInfo = " Trades and Market"; }
+                    }
 					
-                    InputForm AutoConfirm_passKeyForm = new InputForm("To activate Auto-Confirm please enter:\n" + AutoConfirm_Passkey, true);
+                    InputForm AutoConfirm_passKeyForm = new InputForm("To activate Auto-Confirm" + AutoConfirmInfo + " enter:\n" + AutoConfirm_Passkey, true);
                     AutoConfirm_passKeyForm.ShowDialog();
                     if (!AutoConfirm_passKeyForm.Canceled)
                     {
@@ -120,7 +127,7 @@ namespace Steam_Desktop_Authenticator
             {
 				string AutoConfirm_Passkey = SecureStartAutoConfirm();
 				
-                InputForm AutoConfirm_passKeyForm = new InputForm("To activate Auto-Confirm please enter:\n" + AutoConfirm_Passkey, true);
+                InputForm AutoConfirm_passKeyForm = new InputForm("To activate Auto-Confirm enter:\n" + AutoConfirm_Passkey, true);
                 AutoConfirm_passKeyForm.ShowDialog();
                 if (!AutoConfirm_passKeyForm.Canceled)
                 {

--- a/Steam Desktop Authenticator/Manifest.cs
+++ b/Steam Desktop Authenticator/Manifest.cs
@@ -45,11 +45,9 @@ namespace Steam_Desktop_Authenticator
 
         public static string SecureStartAutoConfirm()
         {
-            // random lenght
-                Random r = new Random();
-                int length = r.Next(4, 6);
             // random string
-                 const string chars = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789"; // removed similar characters: I O i l o 0 1
+            	int length = 3;
+                const string chars = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789"; // removed similar characters: I O i l o 0 1
                 var random = new Random();
                 string RandomSecureString = new string(Enumerable.Repeat(chars, length).Select(s => s[random.Next(s.Length)]).ToArray());
 

--- a/Steam Desktop Authenticator/Manifest.cs
+++ b/Steam Desktop Authenticator/Manifest.cs
@@ -43,6 +43,106 @@ namespace Steam_Desktop_Authenticator
             return Path.GetDirectoryName(System.Reflection.Assembly.GetEntryAssembly().Location);
         }
 
+        public static string SecureStartAutoConfirm()
+        {
+            // random lenght
+                Random r = new Random();
+                int length = r.Next(4, 6);
+            // random string
+                 const string chars = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghjkmnpqrstuvwxyz23456789"; // removed similar characters: I O i l o 0 1
+                var random = new Random();
+                string RandomSecureString = new string(Enumerable.Repeat(chars, length).Select(s => s[random.Next(s.Length)]).ToArray());
+
+            return RandomSecureString;
+        }
+
+        public static bool AutoConfirmTrades_IsStartedSecurely_Data = false;
+        public static bool AutoConfirMarketm_IsStartedSecurely_Data = false;
+        public static bool AutoConfirm_IsStartedSecurely(string Function = "",  bool ChangeStatus = false, string PartTradesOrMarket = "")
+        {
+            bool Status_AutoConfirmTrades = false;
+            if (Function == "read")
+            {
+                if (PartTradesOrMarket == "trades") { Status_AutoConfirmTrades = AutoConfirmTrades_IsStartedSecurely_Data; }
+                if (PartTradesOrMarket == "market") { Status_AutoConfirmTrades = AutoConfirMarketm_IsStartedSecurely_Data; }
+            }
+            else if (Function == "set")
+            {
+                if (PartTradesOrMarket == "trades") { AutoConfirmTrades_IsStartedSecurely_Data = ChangeStatus; }
+                if (PartTradesOrMarket == "market") { AutoConfirMarketm_IsStartedSecurely_Data = ChangeStatus; }
+            }
+
+            return Status_AutoConfirmTrades;
+        }
+
+        public static bool PromptForSecureActvationAutoConfirm(string UseFormFor)
+        {
+            bool AutoConfirm_passKeyValid = false;
+
+            // Confirm at Startup
+            if (UseFormFor == "startup_confirmation")
+            {
+                int TotalRentryTimes_AutoConfirm_Passkey = 0;
+                while (!AutoConfirm_passKeyValid && 3 > TotalRentryTimes_AutoConfirm_Passkey)
+                {
+                    TotalRentryTimes_AutoConfirm_Passkey++;
+
+					string AutoConfirm_Passkey = SecureStartAutoConfirm();
+					
+                    InputForm AutoConfirm_passKeyForm = new InputForm("To activate Auto-Confirm please enter:\n" + AutoConfirm_Passkey, true);
+                    AutoConfirm_passKeyForm.ShowDialog();
+                    if (!AutoConfirm_passKeyForm.Canceled)
+                    {
+                        if (AutoConfirm_passKeyForm.txtBox.Text.ToLower() == AutoConfirm_Passkey.ToLower())
+                        {
+                            AutoConfirm_passKeyValid = true;
+                        }
+                        else {
+                            if (TotalRentryTimes_AutoConfirm_Passkey == 3)
+                            {
+                                MessageBox.Show("Auto-Confirm Passkey is invalid.\nAuto-Confirm is now disabled! Confirmation Popups are enabled!");
+                            }
+                            else {
+                                MessageBox.Show("Auto-Confirm Passkey is invalid.");
+                            }
+                        }
+                    }
+                    else
+                    {
+						MessageBox.Show("Auto-Confirm Passkey is invalid.\nAuto-Confirm is now disabled! Confirmation Popups are enabled!");
+                        return false;
+                    }
+                }
+            }
+
+            // Confirm at settings Change
+            if (UseFormFor == "settings_change")
+            {
+				string AutoConfirm_Passkey = SecureStartAutoConfirm();
+				
+                InputForm AutoConfirm_passKeyForm = new InputForm("To activate Auto-Confirm please enter:\n" + AutoConfirm_Passkey, true);
+                AutoConfirm_passKeyForm.ShowDialog();
+                if (!AutoConfirm_passKeyForm.Canceled)
+                {
+                    if (AutoConfirm_passKeyForm.txtBox.Text.ToLower() == AutoConfirm_Passkey.ToLower())
+                    {
+                        AutoConfirm_passKeyValid = true;
+                    }
+                    else {
+                        MessageBox.Show("Auto-Confirm Passkey is invalid.");
+                    }
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            // return
+            return AutoConfirm_passKeyValid;
+        }
+        
+
         public static Manifest GetManifest(bool forceLoad = false)
         {
             // Check if already staticly loaded

--- a/Steam Desktop Authenticator/SettingsForm.cs
+++ b/Steam Desktop Authenticator/SettingsForm.cs
@@ -132,7 +132,17 @@ namespace Steam_Desktop_Authenticator
 
                     if (EnableAutoConfirm_Market_Warning == true)
                     {
-                        bool EnableAutoConfirm_Market_Securely_atStartup = Manifest.PromptForSecureActvationAutoConfirm("settings_change");
+                        bool EnableAutoConfirm_Market_Securely_atStartup = false;
+                        if (manifest.Encrypted)
+                        {
+                            // secure
+                            EnableAutoConfirm_Market_Securely_atStartup = Manifest.PromptForSecureActvationAutoConfirm("settings_change");
+                        }
+                        else {
+                            // unsecure
+                            EnableAutoConfirm_Market_Securely_atStartup = true;
+                        }
+
                         if (EnableAutoConfirm_Market_Securely_atStartup == true)
                         {
                             Manifest.AutoConfirm_IsStartedSecurely("set", true, "market");
@@ -161,7 +171,17 @@ namespace Steam_Desktop_Authenticator
 
                     if (EnableAutoConfirm_Trades_Warning == true)
                     {
-                        bool EnableAutoConfirm_Trades_Securely_atStartup = Manifest.PromptForSecureActvationAutoConfirm("settings_change");
+                        bool EnableAutoConfirm_Trades_Securely_atStartup = false;
+                        if (manifest.Encrypted)
+                        {
+                            // secure
+                            EnableAutoConfirm_Trades_Securely_atStartup = Manifest.PromptForSecureActvationAutoConfirm("settings_change");
+                        }
+                        else {
+                            // unsecure
+                            EnableAutoConfirm_Trades_Securely_atStartup = true;
+                        }
+
                         if (EnableAutoConfirm_Trades_Securely_atStartup == true)
                         {
                             Manifest.AutoConfirm_IsStartedSecurely("set", true, "trades");

--- a/Steam Desktop Authenticator/SettingsForm.cs
+++ b/Steam Desktop Authenticator/SettingsForm.cs
@@ -21,8 +21,22 @@ namespace Steam_Desktop_Authenticator
             numPeriodicInterval.Value = manifest.PeriodicCheckingInterval;
             chkCheckAll.Checked = manifest.CheckAllAccounts;
 
-            // set Auto Confirm
-            Read_AutoConfirmTrades_IsStartedSecurely = Manifest.AutoConfirm_IsStartedSecurely("read", false, "trades");
+
+
+
+
+
+
+            // set Auto Confirm Trades
+            if (manifest.Encrypted)
+            {
+                /*secure*/
+                Read_AutoConfirmTrades_IsStartedSecurely = Manifest.AutoConfirm_IsStartedSecurely("read", false, "trades");
+            }
+            else {
+                /*unsecure*/
+                Read_AutoConfirmTrades_IsStartedSecurely = true;
+            }
             if (Read_AutoConfirmTrades_IsStartedSecurely == true)
             {
                 chkConfirmTrades.Checked = manifest.AutoConfirmTrades;
@@ -31,7 +45,14 @@ namespace Steam_Desktop_Authenticator
                 chkConfirmTrades.Checked = false;
             }
 
-            Read_AutoConfirmMarket_IsStartedSecurely = Manifest.AutoConfirm_IsStartedSecurely("read", false, "market");
+            // set Auto Confirm Market
+            if (manifest.Encrypted) {
+                /*secure*/
+                Read_AutoConfirmMarket_IsStartedSecurely = Manifest.AutoConfirm_IsStartedSecurely("read", false, "market");
+            } else {
+                /*unsecure*/
+                Read_AutoConfirmMarket_IsStartedSecurely = true;
+            }
             if (Read_AutoConfirmMarket_IsStartedSecurely == true)
             {
                 chkConfirmMarket.Checked = manifest.AutoConfirmMarketTransactions;
@@ -39,6 +60,7 @@ namespace Steam_Desktop_Authenticator
             else {
                 chkConfirmMarket.Checked = false;
             }
+            
 
             SetControlsEnabledState(chkPeriodicChecking.Checked);
 


### PR DESCRIPTION
Auto-Confirm can't be hacked

User will know the the app starts that he has auto-confirm ON

At startup It will ask the user to enter a random string generated by the app to activate Auto-confirm if the settings for auto-confirm trades or market = true
In settings if for example user has Auto-confirm Trades unchecked and the user tick's it, it will receive the default warning, followed by to Activation form asking the user to enter the random string generated. 

If the user cancel's that form the Auto confirm will be off, & he will get popups to confirm trades

This way the app is secure and can't be hacked to Auto-Confirm stuff, and It's also best for people who may leave this option on by mistake (they get that reminder at startup about their Auto-confirm options)