### PR TITLE
Fix Double Confirmations and Unhandled Exceptions

### DIFF
--- a/Steam Desktop Authenticator/MainForm.cs
+++ b/Steam Desktop Authenticator/MainForm.cs
@@ -463,7 +463,6 @@ namespace Steam_Desktop_Authenticator
             {
                 lblStatus.Text = "Checking Confirmations Failed";
             }
-            }
         }
 
 

--- a/Steam Desktop Authenticator/MainForm.cs
+++ b/Steam Desktop Authenticator/MainForm.cs
@@ -427,11 +427,17 @@ namespace Steam_Desktop_Authenticator
                         foreach(var conf in tmp)
                         {
                             if (conf.ConfType == Confirmation.ConfirmationType.MarketSellTransaction && manifest.AutoConfirmMarketTransactions)
-                                acc.AcceptConfirmation(conf);
-                            else if (conf.ConfType == Confirmation.ConfirmationType.Trade && manifest.AutoConfirmTrades)
-                                acc.AcceptConfirmation(conf);
-                            else
-                                confs.Add(conf);
+                                {
+                                    acc.AcceptConfirmation(conf);
+                                else if (conf.ConfType == Confirmation.ConfirmationType.Trade && manifest.AutoConfirmTrades)
+                                    {
+                                        acc.AcceptConfirmation(conf);
+                                    else if (!manifest.AutoConfirmTrades && !manifest.AutoConfirmMarketTransactions)
+                                        {
+                                            confs.Add(conf);
+                                        }
+                                    }
+                                }
                         }
                     }
                     catch (SteamGuardAccount.WGTokenInvalidException)
@@ -452,6 +458,11 @@ namespace Steam_Desktop_Authenticator
             catch (SteamGuardAccount.WGTokenInvalidException)
             {
                 lblStatus.Text = "";
+            }
+            catch
+            {
+                lblStatus.Text = "Checking Confirmations Failed";
+            }
             }
         }
 


### PR DESCRIPTION
Theoretically fixes an issue where all market/trade confirmations show up twice, and theoretically fixes another issue where disconnecting your internet or letting your computer go to sleep leads to an unhandled exception as soon we check for new trade/market confirmations.

I'm still very new to this, feel free to change it so it works properly.
