### PR TITLE
Wrong parameter for tag

### DIFF
--- a/Steam Desktop Authenticator/ConfirmationFormWeb.cs
+++ b/Steam Desktop Authenticator/ConfirmationFormWeb.cs
@@ -74,7 +74,7 @@ namespace Steam_Desktop_Authenticator
                         // get details
                         success('{2}');
                     }}
-                }}", steamAccount.GenerateConfirmationQueryParams("allow"), steamAccount.GenerateConfirmationQueryParams("allow"), urlParams);
+                }}", steamAccount.GenerateConfirmationQueryParams("allow"), steamAccount.GenerateConfirmationQueryParams("cancel"), urlParams);
                 browser.ExecuteScriptAsync(script);
             }
         }


### PR DESCRIPTION
Just a little fix. Webrequest to cancel a confirmation were send with following parameters before:

/mobileconf/ajaxop?
op=cancel&
p=[android:DEVICEID]&
a=[STEAMID]&
k=[CONFIRMATION-KEY]&
t=[SERVERTIME]&
m=android&
tag=allow& <<<<<<<<<
cid=[CID]&
ck=[CK]

The Confirmation (cancel) is succesfull w/o this anyway.