### PR TITLE
Added su to command when checking for steamapp

### DIFF
--- a/Steam Desktop Authenticator/PhoneBridge.cs
+++ b/Steam Desktop Authenticator/PhoneBridge.cs
@@ -366,7 +366,7 @@ namespace Steam_Desktop_Authenticator
 
             console.OutputDataReceived += f1;
 
-            ExecuteCommand("adb shell \"cd /data/data/com.valvesoftware.android.steam.community && echo Yes\"");
+            ExecuteCommand("adb shell \"su -c 'cd /data/data/com.valvesoftware.android.steam.community && echo Yes'\"");
             mre.Wait();
 
             console.OutputDataReceived -= f1;


### PR DESCRIPTION
On the Oneplus Two you get a permission denied when checking for the steamcommunity folder on the device resulting in a crash. Since non root method is disabled, there should be no reason not using cd with root.

Using LineageOS 14.1-20170518-NIGHTLY
Android version: 7.1.2 

With the su check it works again.