### PR TITLE
Added support for newer ADB versions

### DIFF
--- a/Steam Desktop Authenticator/PhoneBridge.cs
+++ b/Steam Desktop Authenticator/PhoneBridge.cs
@@ -75,8 +75,6 @@ namespace Steam_Desktop_Authenticator
         {
             if (!skipChecks) AppendToLog("");
             InitConsole(); // Init the console
-
-            GetAdbVersion();
             
             if (!skipChecks)
             {
@@ -89,24 +87,29 @@ namespace Steam_Desktop_Authenticator
                     return null;
                 }
             }
-
+            
+            CheckAdbVersion();
             bool root = IsRooted();
 
             //root = false; // DEBUG ///////////////////////
 
             SteamGuardAccount acc;
-            string json;
+            string json = null;
 
             if (root)
             {
-                OnOutputLog("Using root method");
-                json = PullJson(id);
+                if (!skipChecks && !SteamAppInstalled()) {
+                    OnPhoneBridgeError("Steam Community app not installed");
+                }
+                else {
+                    OnOutputLog("Using root method");
+                    json = PullJson(id); 
+                }
             }
             else
             {
                 OnOutputLog("Steam has blocked the non-root method of copying data from their app.");
                 OnOutputLog("Your phone must now be rooted to use this.");
-                json = null;
                 //json = PullJsonNoRoot(id);
             }
 
@@ -130,8 +133,7 @@ namespace Steam_Desktop_Authenticator
         private string ErrorsFound()
         {
             if (!CheckAdb()) return "ADB not found";
-            if (!DeviceUp()) return "Device not detected";
-            if (!SteamAppInstalled()) return "Steam Community app not installed";
+            if (!DeviceUp()) return "Device not detected"; 
             return "";
         }
 
@@ -410,7 +412,7 @@ namespace Steam_Desktop_Authenticator
             return root;
         }
         
-        private void GetAdbVersion()
+        private void CheckAdbVersion()
         {
             OnOutputLog("Checking ADB version");
             string versionString = "";

--- a/Steam Desktop Authenticator/PhoneBridge.cs
+++ b/Steam Desktop Authenticator/PhoneBridge.cs
@@ -421,7 +421,10 @@ namespace Steam_Desktop_Authenticator
             {
                 if (e.Data.Contains(">@") || e.Data == "" || e.Data.Contains("Revision")) return;
 
-                versionString = new string(e.Data.ToCharArray().Where(char.IsDigit).ToArray());
+                if(e.Data.Contains("Android Debug Bridge")) {
+                    versionString = new string(e.Data.ToCharArray().Where(char.IsDigit).ToArray());
+                }
+
                 mre.Set();
             };
 


### PR DESCRIPTION
In newer adb versions > 1.0.36 you need to add -n command arg, or the console will hang after the first su command. I added an adb version check and use the -n arg in versions > 1.0.36. This should fix most of the Steamappnotfound and "checking for steam app hanging" issues.