### PR TITLE
Fix a crash in android import.

### DIFF
--- a/Steam Desktop Authenticator/PhoneBridge.cs
+++ b/Steam Desktop Authenticator/PhoneBridge.cs
@@ -55,7 +55,7 @@ namespace Steam_Desktop_Authenticator
 
             console.OutputDataReceived += (sender, e) =>
             {
-                if (e.Data.Contains(">@") || !OutputToConsole || e.Data == "") return;
+                if (e?.Data == null || e.Data.Contains(">@") || !OutputToConsole || e.Data == "") return;
                 if (OutputToConsole)
                     Console.WriteLine(e.Data);
                 if (OutputToLog)


### PR DESCRIPTION
This fixes a crash that happens when the data property is null. It happened on my machine (windows 10) so I guess that can happen on other setups too.