### PR TITLE
Custom maFiles directory command line switch

### DIFF
--- a/Steam Desktop Authenticator/Program.cs
+++ b/Steam Desktop Authenticator/Program.cs
@@ -21,6 +21,10 @@ namespace Steam_Desktop_Authenticator
           HelpText = "Start minimized")]
         public bool Silent { get; set; }
 
+        [Option('d', "directory", Required = false,
+            HelpText = "Custom maFiles directory", DefaultValue = null)]
+        public string MaFilesDirectory { get; set; }
+
         [ParserState]
         public IParserState LastParserState { get; set; }
 
@@ -78,6 +82,7 @@ namespace Steam_Desktop_Authenticator
             Application.EnableVisualStyles();
             Application.SetCompatibleTextRenderingDefault(false);
 
+            Manifest.MaDir = options.MaFilesDirectory;
             Manifest man;
 
             try

--- a/Steam Desktop Authenticator/WelcomeForm.cs
+++ b/Steam Desktop Authenticator/WelcomeForm.cs
@@ -59,19 +59,16 @@ namespace Steam_Desktop_Authenticator
                     return;
                 }
 
-                // Copy the contents of the config dir to the new config dir
-                string currentPath = Manifest.GetExecutableDir();
-
                 // Create config dir if we don't have it
-                if (!Directory.Exists(currentPath + "/maFiles"))
+                if (!Directory.Exists(Manifest.MaDir))
                 {
-                    Directory.CreateDirectory(currentPath + "/maFiles");
+                    Directory.CreateDirectory(Manifest.MaDir);
                 }
 
                 // Copy all files from the old dir to the new one
                 foreach (string newPath in Directory.GetFiles(pathToCopy, "*.*", SearchOption.AllDirectories))
                 {
-                    File.Copy(newPath, newPath.Replace(pathToCopy, currentPath + "/maFiles"), true);
+                    File.Copy(newPath, newPath.Replace(pathToCopy, Manifest.MaDir), true);
                 }
 
                 // Set first run in manifest


### PR DESCRIPTION
This will allow to automatically backup files with sync clients such as dropbox which is perfectly fine if maFiles are encrypted. No graphical option is provided to not increase UI complexity.

This also provides a quick way to replace the maFiles default dir if it will ever be needed.