### PR TITLE
add support for email confirmation

### DIFF
--- a/Steam Desktop Authenticator/LoginForm.cs
+++ b/Steam Desktop Authenticator/LoginForm.cs
@@ -159,6 +159,10 @@ namespace Steam_Desktop_Authenticator
                         linker.PhoneNumber = null;
                         break;
 
+                    case AuthenticatorLinker.LinkResult.MustConfirmEmail:
+                        MessageBox.Show("Please check your email, and click the link Steam sent you before continuing.");
+                        break;
+
                     case AuthenticatorLinker.LinkResult.GeneralFailure:
                         MessageBox.Show("Error adding your phone number. Steam returned \"GeneralFailure\".");
                         this.Close();


### PR DESCRIPTION
Recently steam changed procedure of adding authenticator - now before adding phone number it's required to confirm email once more. This PR adds support for this step. 
For this to work, changes needed in SteamAuth lib first, so this PR will only be useful if/when https://github.com/geel9/SteamAuth/pull/81 will get merged.
