### PR TITLE
Revert "Alphabetical sorting of accounts"

### DIFF
--- a/Steam Desktop Authenticator/MainForm.cs
+++ b/Steam Desktop Authenticator/MainForm.cs
@@ -591,9 +591,6 @@ namespace Steam_Desktop_Authenticator
 
                 listAccounts.SelectedIndex = 0;
                 trayAccountList.SelectedIndex = 0;
-
-                listAccounts.Sorted = true;
-                trayAccountList.Sorted = true;
             }
             menuDeactivateAuthenticator.Enabled = btnTradeConfirmations.Enabled = allAccounts.Length > 0;
         }


### PR DESCRIPTION
Reverts Jessecar96/SteamDesktopAuthenticator#527

Some users have pointed out (in #610) that forcing the alphabetical sorting has broken some features. Since it breaks features (unverified) that have worked in previous versions and since the solution I proposed is very rudimentary I feel it should be reverted.