### PR TITLE
Fixed Exception after pressing "X" of the TradePopupForm when trying to reopen the window

### DIFF
--- a/Steam Desktop Authenticator/TradePopupForm.Designer.cs
+++ b/Steam Desktop Authenticator/TradePopupForm.Designer.cs
@@ -106,6 +106,7 @@
             this.Name = "TradePopupForm";
             this.Text = "New confirmation";
             this.TopMost = true;
+            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.TradePopupForm_FormClosing);
             this.Load += new System.EventHandler(this.TradePopupForm_Load);
             this.ResumeLayout(false);
 

--- a/Steam Desktop Authenticator/TradePopupForm.cs
+++ b/Steam Desktop Authenticator/TradePopupForm.cs
@@ -1,12 +1,7 @@
 ﻿using SteamAuth;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
-using System.Data;
 using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Windows.Forms;
 
 namespace Steam_Desktop_Authenticator
@@ -96,6 +91,12 @@ namespace Steam_Desktop_Authenticator
                 //TODO: Re-add confirmation description support to SteamAuth.
                 lblDesc.Text = "Confirmation";
             }
+        }
+
+        private void TradePopupForm_FormClosing(object sender, FormClosingEventArgs e)
+        {
+            e.Cancel = true;
+            this.Hide();
         }
 
         public void Popup()


### PR DESCRIPTION
If I'm honest could have just removed the border of the window completely but this way works too :)
(Could just make it "deny" the confirmation when pressing x.)
