### PR TITLE
Remove Deprecated Git URL From Git Modules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/SteamAuth"]
 	path = lib/SteamAuth
-	url = git://github.com/geel9/SteamAuth
+	url = https://github.com/geel9/SteamAuth


### PR DESCRIPTION
Since Github no longer supports Git URLS, I changed it to HTTPS as per the site recommendation.