### PR TITLE
LoginForm. Fix issue 990. btnSteamLogin_Click add refresh accessToken

### DIFF
--- a/Steam Desktop Authenticator/LoginForm.cs
+++ b/Steam Desktop Authenticator/LoginForm.cs
@@ -124,9 +124,25 @@ namespace Steam_Desktop_Authenticator
             SessionData sessionData = new SessionData()
             {
                 SteamID = authSession.SteamID.ConvertToUInt64(),
-                AccessToken = pollResponse.AccessToken,
+                // As of 2023-09-12, Steam doesn't actually generate access tokens when you login anymore. It's just an empty string.
+                //AccessToken = pollResponse.AccessToken,
                 RefreshToken = pollResponse.RefreshToken,
             };
+
+            // Check for a valid access token, refresh it if needed
+            if (sessionData.IsAccessTokenExpired())
+            {
+                try
+                {
+                    await sessionData.RefreshAccessToken();
+                }
+                catch (Exception ex)
+                {
+                    MessageBox.Show(ex.Message, "Steam Login Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    this.Close();
+                    return;
+                }
+            }
 
             //Login succeeded
             this.Session = sessionData;


### PR DESCRIPTION
I`m not familiar with C#. But i needed to fix this for myself

LoginForm. Fix issue #990 #993 . btnSteamLogin_Click add refresh accessToken before assign sessionData