### PR TITLE
Windows 7/8.1 is no longer supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 <h3 align="center" style="margin-bottom:0">
   <a href="https://github.com/Jessecar96/SteamDesktopAuthenticator/releases/latest">Download here</a>
 </h3>
-<p align="center">Supports Windows 10 and up.</p>
+<p align="center">Supports Windows 10, version 20H2 and up.</p>
 <br>
 
 **Clicking "Download ZIP" will not work!** This project uses git submodules so you must use git to download it properly. Using [GitHub Desktop](https://desktop.github.com/) is an easy way to do that.
@@ -29,7 +29,7 @@ IF you lost your `maFiles` OR lost your encryption key, go [here](https://store.
 If you did not follow the directions and did not write your revocation code down, you're well and truly screwed. The only option is beg to [Steam Support](https://support.steampowered.com/) and say you lost your mobile authenticator and the revocation code.
 
 ## Detailed setup instructions
-- Download & Install [.NET Framework 4.7.2](https://www.microsoft.com/net/download/dotnet-framework-runtime/net472) if you're using Windows 7. Windows 8 and above should do this automatically for you.
+- Download & Install [.NET Framework 4.8.1](https://www.microsoft.com/net/download/dotnet-framework-runtime/net481) if you're using Windows 11, version 22H2 and above should do this automatically for you.
 - Visit [the releases page](https://github.com/Jessecar96/SteamDesktopAuthenticator/releases) and download the latest .zip (not the source code one).
 - Extract the files somewhere very safe on your computer. If you lose the files you can lose access to your Steam account.
 - Run `Steam Desktop Authenticator.exe` and click the button to set up a new account.

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 <h3 align="center" style="margin-bottom:0">
   <a href="https://github.com/Jessecar96/SteamDesktopAuthenticator/releases/latest">Download here</a>
 </h3>
-<p align="center">Supports Windows 7 and up.</p>
+<p align="center">Supports Windows 10 and up.</p>
 <br>
 
 **Clicking "Download ZIP" will not work!** This project uses git submodules so you must use git to download it properly. Using [GitHub Desktop](https://desktop.github.com/) is an easy way to do that.

--- a/Steam Desktop Authenticator/App.config
+++ b/Steam Desktop Authenticator/App.config
@@ -1,18 +1,18 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup> 
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.2" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8.1"/>
   </startup>
   <system.net>
     <settings>
-      <httpWebRequest useUnsafeHeaderParsing="true" />
+      <httpWebRequest useUnsafeHeaderParsing="true"/>
     </settings>
   </system.net>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0" />
+        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-6.0.0.0" newVersion="6.0.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/Steam Desktop Authenticator/PhoneInputForm.Designer.cs
+++ b/Steam Desktop Authenticator/PhoneInputForm.Designer.cs
@@ -44,7 +44,7 @@
             this.txtCountryCode.Font = new System.Drawing.Font("Segoe UI", 14.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.txtCountryCode.Location = new System.Drawing.Point(11, 98);
             this.txtCountryCode.Margin = new System.Windows.Forms.Padding(2);
-            this.txtCountryCode.Mask = "AA";
+            this.txtCountryCode.Mask = "AAAA";
             this.txtCountryCode.Name = "txtCountryCode";
             this.txtCountryCode.Size = new System.Drawing.Size(68, 33);
             this.txtCountryCode.TabIndex = 0;
@@ -72,7 +72,7 @@
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(276, 17);
             this.label2.TabIndex = 2;
-            this.label2.Text = "Two letter country code of the phone number:";
+            this.label2.Text = "Country code of the phone number:";
             // 
             // label3
             // 

--- a/Steam Desktop Authenticator/Steam Desktop Authenticator.csproj
+++ b/Steam Desktop Authenticator/Steam Desktop Authenticator.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Steam_Desktop_Authenticator</RootNamespace>
     <AssemblyName>Steam Desktop Authenticator</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <IsWebBootstrapper>false</IsWebBootstrapper>


### PR DESCRIPTION
Microsoft ended security updates and technical support for Windows 7 in January 2020 and for Windows 8.1 in January 2023, also Steam will stop supporting the Windows 7/8.1 in January 1 2024, run SDA on Windows 7/8.1 is no safe, Please upgrade OS