### PR TITLE
Implement case-insensitive account search

### DIFF
--- a/Steam Desktop Authenticator/MainForm.cs
+++ b/Steam Desktop Authenticator/MainForm.cs
@@ -628,7 +628,7 @@ namespace Steam_Desktop_Authenticator
             }
             else
             {
-                return f.Contains(txtAccSearch.Text);
+                return f.Contains(txtAccSearch.Text.ToLower());
             }
         }
 


### PR DESCRIPTION
This commit introduces a change to allows for case-insensitive account search. Previously, the search functionality was case-sensitive.