### PR TITLE
Fixed support for broken icons

### DIFF
--- a/Steam Desktop Authenticator/ConfirmationFormWeb.cs
+++ b/Steam Desktop Authenticator/ConfirmationFormWeb.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using System.Windows.Forms;
 using SteamAuth;
 using System.Drawing.Drawing2D;
+using System.Net;
 
 namespace Steam_Desktop_Authenticator
 {
@@ -64,12 +65,30 @@ namespace Steam_Desktop_Authenticator
                             e.Graphics.FillRectangle(brush, panel.ClientRectangle);
                         }
                     };
-                    
+
                     if (!string.IsNullOrEmpty(confirmation.Icon))
                     {
-                       PictureBox pictureBox = new PictureBox() { Width = 60, Height = 60, Location = new Point(20, 20), SizeMode = PictureBoxSizeMode.Zoom };
-                       pictureBox.Load(confirmation.Icon);
-                       panel.Controls.Add(pictureBox);
+                        PictureBox pictureBox = new PictureBox() { Width = 60, Height = 60, Location = new Point(20, 20), SizeMode = PictureBoxSizeMode.Zoom };
+                        try
+                        {
+                            pictureBox.Load(confirmation.Icon);
+                        }
+                        catch (WebException ex)
+                        {
+                            if (ex.Status == WebExceptionStatus.ProtocolError)
+                            {
+                                if (ex.Response is HttpWebResponse response)
+                                {
+                                    Label exLabel = new Label() { Text = "Icon error code: " + (int)response.StatusCode, AutoSize = false, ForeColor = Color.Red, Width = 60, Height = 60, Location = new Point(20, 20), TextAlign = ContentAlignment.MiddleCenter };
+                                    panel.Controls.Add(exLabel);
+                                }
+                            }
+                        }
+                        catch (Exception ex)
+                        {
+                            Console.WriteLine("Failed to load profile icon: " + ex.Message);
+                        }
+                        panel.Controls.Add(pictureBox);
                     }
 
                     Label nameLabel = new Label()


### PR DESCRIPTION
When trying to confirm a trade to an account with a broken icon, the confirmation page is not created properly.
`404`:
![image](https://github.com/Jessecar96/SteamDesktopAuthenticator/assets/7782218/98e7f1d4-dd2c-435e-b2e5-4c026f3bc28f)

Everything works as it should with this fix:
![image](https://github.com/Jessecar96/SteamDesktopAuthenticator/assets/7782218/8e807e1a-81fd-45e0-a851-ef5609f7714a)

If you're wondering what a broken avatar looks like, [here's an example](https://steamcommunity.com/id/internetexp/).